### PR TITLE
Update Indicative SDK Version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.indicative.client.android:Indicative-Android:1.0.1'
+    implementation 'com.indicative.client.android:Indicative-Android:1.1.0'
 }
   


### PR DESCRIPTION
## Proposed Changes

  - Updated the Indicative Android dependency to support the latest Indicative SDK.  This specific fix relates to removing support for org.apache.http.legacy.